### PR TITLE
Add React front end with management script

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import os
+import signal
+
+PID_FILE = 'app.pid'
+
+
+def start():
+    if os.path.exists(PID_FILE):
+        print('Server already running.')
+        return
+    try:
+        proc = subprocess.Popen(['php', 'artisan', 'serve'])
+        with open(PID_FILE, 'w') as f:
+            f.write(str(proc.pid))
+        print(f'Server started with PID {proc.pid}')
+    except Exception as e:
+        print(f'Failed to start server: {e}')
+
+
+def stop():
+    if not os.path.exists(PID_FILE):
+        print('No PID file found. Is the server running?')
+        return
+    try:
+        with open(PID_FILE) as f:
+            pid = int(f.read())
+        os.kill(pid, signal.SIGTERM)
+        os.remove(PID_FILE)
+        print(f'Server with PID {pid} stopped.')
+    except Exception as e:
+        print(f'Failed to stop server: {e}')
+
+
+def test():
+    try:
+        subprocess.check_call(['php', 'artisan', 'test'])
+    except subprocess.CalledProcessError as e:
+        print('Tests failed')
+        sys.exit(e.returncode)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: manage.py [start|stop|test]')
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    if cmd == 'start':
+        start()
+    elif cmd == 'stop':
+        stop()
+    elif cmd == 'test':
+        test()
+    else:
+        print(f'Unknown command {cmd}')
+        sys.exit(1)

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.1.11",
+        "@vitejs/plugin-react": "^4.1.0",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "tailwindcss": "^4.1.11",
         "vite": "^6.2.4"
     }

--- a/resources/js/App.jsx
+++ b/resources/js/App.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div className="p-6 text-center">
+      <h1 className="text-2xl font-bold">React Frontend</h1>
+      <p className="mt-2 text-gray-600">Welcome to the React-powered page.</p>
+    </div>
+  );
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,0 @@
-import './bootstrap';

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './bootstrap';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('app')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,7 +11,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 
     {{-- Vite CSS (if you're using compiled Tailwind with Laravel Vite) --}}
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/css/app.css', 'resources/js/app.jsx'])
 </head>
 
 <body class="bg-green-50 text-gray-800">

--- a/resources/views/react.blade.php
+++ b/resources/views/react.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>React App</title>
+    @vite(['resources/css/app.css', 'resources/js/app.jsx'])
+</head>
+<body class="antialiased">
+    <div id="app"></div>
+</body>
+</html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -13,7 +13,7 @@
 
     <!-- Styles / Scripts -->
     @if (file_exists(public_path('build/manifest.json')) || file_exists(public_path('hot')))
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @vite(['resources/css/app.css', 'resources/js/app.jsx'])
     @else
         <style>
             /*! tailwindcss v4.0.7 | MIT License | https://tailwindcss.com */
@@ -1975,6 +1975,7 @@
     @if (Route::has('login'))
         <div class="h-14.5 hidden lg:block"></div>
     @endif
+    <div id="app"></div>
 </body>
 
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,4 +28,7 @@ Route::get(
         return view('main');
     }
 );
+Route::get('/react', function () {
+    return view('react');
+});
 Route::post('/logout', [UserController::class, 'logout']);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.jsx'],
             refresh: true,
         }),
+        react(),
     ],
 });


### PR DESCRIPTION
## Summary
- integrate React via Vite
- add minimal React component and view
- update blade templates to include the React build
- add a simple `manage.py` script to start/stop/test the app

## Testing
- `php artisan test` *(fails: `php` command not found)*
- `./manage.py start` *(fails: `php` not found)*
- `./manage.py stop`
- `./manage.py test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686674a1aba083328dcc7de21a0ef141